### PR TITLE
リンクと訪問済みリンクの色をinheritに変更

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -91,10 +91,12 @@ a {
   background-size: 200% auto;
   transition: .3s;
   text-decoration: none;
+  color: inherit;
+  font-style: italic;
 }
 
 a:visited {
-  color: #ff4081;
+  color: inherit;
 }
 
 a:hover {
@@ -103,5 +105,5 @@ a:hover {
 }
 
 a:active {
-  color: #26a69a;
+  color: inherit;
 }


### PR DESCRIPTION
リンクに色が付いていると表示がゴタゴタしてうるさいので黒(inherit)に変更しました。